### PR TITLE
Create Game Request

### DIFF
--- a/examples/xo_android_client/app/build.gradle
+++ b/examples/xo_android_client/app/build.gradle
@@ -20,6 +20,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    // Temporary fix until alpha10
+    packagingOptions {
+        exclude 'META-INF/proguard/androidx-annotations.pro'
+    }
 }
 
 dependencies {
@@ -27,6 +32,7 @@ dependencies {
     implementation files('libs/sawtooth-sdk-protos-v0.1.2-SNAPSHOT.jar')
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation 'com.google.protobuf:protobuf-java:3.6.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/examples/xo_android_client/app/build.gradle
+++ b/examples/xo_android_client/app/build.gradle
@@ -25,7 +25,9 @@ android {
 dependencies {
     implementation files('libs/sawtooth-sdk-signing-v0.1.2-SNAPSHOT.jar')
     implementation files('libs/sawtooth-sdk-protos-v0.1.2-SNAPSHOT.jar')
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'

--- a/examples/xo_android_client/app/src/main/AndroidManifest.xml
+++ b/examples/xo_android_client/app/src/main/AndroidManifest.xml
@@ -2,13 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.bitwise.sawtooth_xo">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
+            android:usesCleartextTraffic="true">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/MainActivity.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/MainActivity.kt
@@ -2,11 +2,16 @@ package io.bitwise.sawtooth_xo
 
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import io.bitwise.sawtooth_xo.state.XoState
+import java.util.UUID
+
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val state =  XoState()
+        state.createGame("game-" + UUID.randomUUID().toString())
         setContentView(R.layout.activity_main)
     }
 }

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/XoState.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/XoState.kt
@@ -1,0 +1,124 @@
+package io.bitwise.sawtooth_xo.state
+
+
+import io.bitwise.sawtooth_xo.state.rest_api.SawtoothRestApi
+import retrofit2.Retrofit
+import io.bitwise.sawtooth_xo.state.rest_api.BatchListResponse
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import android.util.Log
+import com.google.common.io.BaseEncoding
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import retrofit2.converter.gson.GsonConverterFactory
+import sawtooth.sdk.signing.Secp256k1Context
+import sawtooth.sdk.signing.Signer
+import com.google.protobuf.ByteString
+import java.security.MessageDigest
+import sawtooth.sdk.protobuf.*
+import java.util.UUID
+
+
+
+class XoState {
+    private var service: SawtoothRestApi? = null
+    private var signer: Signer? = null
+
+    init {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("http://10.0.2.2:9708")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+        service = retrofit.create<SawtoothRestApi>(SawtoothRestApi::class.java)
+
+        val context = Secp256k1Context()
+        val privateKey = context.newRandomPrivateKey()
+        signer = Signer(context, privateKey)
+    }
+
+    fun createGame(gameName: String) {
+        val createGameTransaction = makeTransaction(gameName, "create", null)
+        val batch = makeBatch(arrayOf(createGameTransaction))
+        sendRequest(batch)
+    }
+
+    private fun makeTransaction(gameName: String, action: String, space: String?): Transaction {
+        val payload ="$gameName,$action,$space"
+
+        val address = makeGameAddress(gameName)
+
+        val header = TransactionHeader.newBuilder()
+            .setSignerPublicKey(signer?.publicKey?.hex())
+            .setFamilyName("xo")
+            .setFamilyVersion("1.0")
+            .addInputs(address)
+            .addOutputs(address)
+            .setPayloadSha512(hash(payload))
+            .setBatcherPublicKey(signer?.publicKey?.hex())
+            .setNonce(UUID.randomUUID().toString())
+            .build()
+
+        val signature = signer?.sign(header.toByteArray())
+
+        return Transaction.newBuilder()
+            .setHeader(header.toByteString())
+            .setPayload(ByteString.copyFrom(payload, "UTF-8"))
+            .setHeaderSignature(signature)
+            .build()
+    }
+
+    private fun makeBatch(transactions: Array<Transaction>): Batch {
+        val batchHeader = BatchHeader.newBuilder()
+            .setSignerPublicKey(signer?.publicKey?.hex())
+            .addAllTransactionIds(transactions.map({transaction -> transaction.headerSignature  }))
+            .build()
+
+        val batch_signature = signer?.sign(batchHeader.toByteArray())
+
+        return Batch.newBuilder()
+            .setHeader(batchHeader.toByteString())
+            .addAllTransactions(transactions.asIterable())
+            .setHeaderSignature(batch_signature)
+            .build()
+    }
+
+    private fun sendRequest(batch: Batch) {
+        val batchList = BatchList.newBuilder()
+            .addBatches(batch)
+            .build()
+            .toByteArray()
+
+        val body = RequestBody.create(MediaType.parse("application/octet-stream"), batchList)
+
+        val call1 = service?.postBatchList(body)
+        call1?.enqueue(object : Callback<BatchListResponse> {
+            override fun onResponse(call: Call<BatchListResponse>, response: Response<BatchListResponse>) {
+                if(response.body() != null) {
+                    Log.d("XO.State", response.body().toString())
+                } else {
+                    Log.d("XO.State", response.toString())
+                }
+            }
+            override fun onFailure(call: Call<BatchListResponse>, t: Throwable) {
+                Log.d("XO.State", t.toString())
+                call.cancel()
+            }
+        })
+    }
+
+    private fun hash(input: String) : String{
+        val digest = MessageDigest.getInstance("SHA-512")
+        digest.reset()
+        digest.update(input.toByteArray())
+        return BaseEncoding.base16().lowerCase().encode(digest.digest())
+    }
+
+    private fun makeGameAddress(gameName: String) : String {
+        val xo_prefix = hash("xo").substring(0, 6)
+        val game_address = hash(gameName).substring(0, 64)
+        return xo_prefix + game_address
+    }
+
+}

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/rest_api/BatchListResponse.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/rest_api/BatchListResponse.kt
@@ -1,0 +1,20 @@
+package io.bitwise.sawtooth_xo.state.rest_api
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Data class for interacting with the Sawtooth REST Api
+ */
+class BatchListResponse(
+    @field:SerializedName("link")
+    /** Returns the link to query the batch status
+     *
+     * @return String link
+     */
+    val link: String
+
+) {
+    override fun toString(): String {
+        return "BatchListResponse(link='$link')"
+    }
+}

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/rest_api/BatchStatusResponse.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/rest_api/BatchStatusResponse.kt
@@ -1,0 +1,93 @@
+package io.bitwise.sawtooth_xo.state.rest_api
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+class BatchStatusResponse(
+    @field:SerializedName("data")
+    @Expose
+    val data: List<Datum>,
+
+    @field:SerializedName("link")
+    @Expose
+    /**
+     * Returns the link to query the batch status
+     *
+     * @return String link
+     */
+    val link: String
+
+) {
+    override fun toString(): String {
+        return "BatchStatusResponse(data=$data, link='$link')"
+    }
+}
+
+class Datum(
+    @field:SerializedName("id")
+    @Expose
+    /** Batch ID
+     *
+     * @return String bach id
+     */
+    val id: String,
+
+    @field:SerializedName("status")
+    @Expose
+    /**
+     * Status of the batch. Possible values are 'COMMITTED', 'INVALID', 'PENDING', and 'UNKNOWN'.
+     *
+     * @return String status
+     */
+    val status: String,
+
+    @field:SerializedName("invalid_transactions")
+    @Expose
+    /**
+     * List of InvalidTransactions if there's any
+     *
+     * @return List InvalidTransactions
+     */
+    val invalidTransactions: List<InvalidTransaction>
+
+
+    ){
+    override fun toString(): String {
+        return "Datum(id='$id', status='$status', invalidTransactions=$invalidTransactions)"
+    }
+}
+
+
+class InvalidTransaction(
+    @field:SerializedName("id")
+    @Expose
+    /**
+     * Id of the transaction
+     *
+     * @return String id
+     */
+    var id: String? = null,
+
+    @field:SerializedName("message")
+    @Expose
+    /**
+     * Message that explains why the transaction failed
+     *
+     * @return String message
+     */
+    var message: String? = null,
+
+    @field:SerializedName("extended_data")
+    @Expose
+    /**
+     * @return String extendedData
+     */
+    var extendedData: String? = null
+) {
+    override fun toString(): String {
+        return "InvalidTransaction(id=$id, message=$message, extendedData=$extendedData)"
+    }
+}
+
+
+

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/rest_api/SawtoothRestApi.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/rest_api/SawtoothRestApi.kt
@@ -1,0 +1,17 @@
+package io.bitwise.sawtooth_xo.state.rest_api
+
+import okhttp3.RequestBody
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface SawtoothRestApi {
+
+    @POST("/batches")
+    fun postBatchList(@Body payload: RequestBody): Call<BatchListResponse>
+
+    @GET("/batch_statuses")
+    fun getBatchStatus(@Query("id") batch_id: String, @Query("wait") wait: Int): Call<BatchStatusResponse>
+}


### PR DESCRIPTION
This PR  adds a service to communicate with the sawtooth-rest-api and adds methods to submit a XO create game transaction and get batch status.

~Depends on #2~ 
#2 has been merged and this PR rebased 

#### To test
1. In `~/sawtooth-sdk-java/examples/xo_android_client/` run `docker-compose up`. This will start the sawtooth network, including the validator, xo-tp, sawtooth-shell, sawtooth-rest-api.

1. Run the App on Android Studio:
   - If you are using a emulator to test the app you don't have to do anything special
   - If you are using a phone to test the app you, on the file XOState line 31, you have to change the URL for the rest api. The new url should be `<your-computer-api-address>:9708`. I was not actually able to test running the app on a phone, as my computer for some reason is not finding my phone when connected via USB.

2. The request to create a game is sent as soon as the app starts up. To make sure it worked:
   - Look at the Android Studio console log. You should see logs as the following:
````
D/XO.State: BatchListResponse(link='http://10.0.2.2:9708/batch_statuses?id=28d477aa88ca5878746fab6be65246c5b0667af13f7b0e9026574cc18f3c4d530708c18880be0da6488a5a725b4f3935339772005a0179fdae14774ccc19e5a9')

D/XO.State: BatchStatusResponse(data=[Datum(id='28d477aa88ca5878746fab6be65246c5b0667af13f7b0e9026574cc18f3c4d530708c18880be0da6488a5a725b4f3935339772005a0179fdae14774ccc19e5a9', status='COMMITTED', invalidTransactions=[])], link='http://10.0.2.2:9708/batch_statuses?id=28d477aa88ca5878746fab6be65246c5b0667af13f7b0e9026574cc18f3c4d530708c18880be0da6488a5a725b4f3935339772005a0179fdae14774ccc19e5a9&wait=5')
````
 - Look at the docker-compose logs in your terminal. 

 - Run `docker exec -it sawtooth-shell bash` and `xo list --url http://rest-api:9708` to log into the sawtooth-shell and use the xo client to confirm that the game was created


#### Known bug

UPDATE: Fixed! 

For some reason that I have not identified yet, depending on the name of the game the validator is returning a INVALID BATCH message. The only game name that I know is eliciting this behavior is `MyOtherGame3`. Right now in the code the game name is generated as a UUID. And depending on the UUID generated, the validator also returns an INVALID BATCH response.
If you run into this bug you'll see this log in Android Studio
````
2018-11-16 11:33:21.889 21666-21666/io.bitwise.sawtooth_xo D/XO.State: Response{protocol=http/1.1, code=400, message=Bad Request, url=http://10.0.2.2:9708/batches}
````

And this log where docker-compose is running
````
sawtooth-rest-api | [2018-11-16 17:33:22.566 DEBUG    route_handlers] Received CLIENT_BATCH_SUBMIT_RESPONSE response from validator with status INVALID_BATCH

````