### PR TITLE
Add tabs to game list view

### DIFF
--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/GameBoardActivity.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/GameBoardActivity.kt
@@ -6,14 +6,16 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
 import android.widget.Toast
-import io.bitwise.sawtooth_xo.state.XoState
+import io.bitwise.sawtooth_xo.state.rest_api.XORequestHandler
 
 class GameBoardActivity : AppCompatActivity() {
+    private var requestHandler: XORequestHandler? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_game_board)
         setSupportActionBar(findViewById(R.id.action_menu))
+        requestHandler = XORequestHandler(getPrivateKey(this))
 
     }
 
@@ -24,14 +26,13 @@ class GameBoardActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
         R.id.send_transaction -> {
-            val state =  XoState()
             val editText = findViewById<EditText>(R.id.gameName)
             val message = editText.text.toString()
             if(message.isBlank()){
                 Toast.makeText(applicationContext, "Please, enter a name for the game.", Toast.LENGTH_LONG).show()
             }
             else {
-                state.createGame(message, applicationContext)
+                requestHandler?.createGame(message, applicationContext)
             }
             true
         }
@@ -42,7 +43,3 @@ class GameBoardActivity : AppCompatActivity() {
         }
     }
 }
-
-
-
-

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/MainActivity.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/MainActivity.kt
@@ -5,11 +5,14 @@ import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.support.design.widget.FloatingActionButton
+import android.support.design.widget.TabLayout
+import android.support.v4.view.ViewPager
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
+import io.bitwise.sawtooth_xo.adapters.PagerAdapter
 import io.bitwise.sawtooth_xo.models.Game
 import io.bitwise.sawtooth_xo.viewmodels.GameViewModel
-
 
 class MainActivity : AppCompatActivity(),  GameListFragment.OnListFragmentInteractionListener{
 
@@ -18,14 +21,36 @@ class MainActivity : AppCompatActivity(),  GameListFragment.OnListFragmentIntera
 
         setContentView(R.layout.activity_main)
         setSupportActionBar(findViewById(R.id.list_view_toolbar))
+        val viewPager = findViewById<ViewPager>(R.id.pager)
+        setupViewPager(viewPager)
+        val tabs = findViewById<View>(R.id.tabs) as TabLayout
+        tabs.setupWithViewPager(viewPager)
 
 
         val fab: FloatingActionButton = findViewById(R.id.newGameFloatingButton)
-        fab.setOnClickListener { _ ->
+        fab.setOnClickListener {
             val intent = Intent(this, GameBoardActivity::class.java)
             startActivity(intent)
         }
+    }
 
+    private fun setupViewPager(viewPager: ViewPager) {
+        val adapter = PagerAdapter(supportFragmentManager)
+        val privateKey = getPrivateKey(this)
+        val publicKey = getPublicKey(this, privateKey)
+        adapter.addFragment(setUpFragment(getString(R.string.PlayTab), publicKey),  getString(R.string.PlayTab))
+        adapter.addFragment(setUpFragment(getString(R.string.WatchTab), publicKey), getString(R.string.WatchTab))
+        adapter.addFragment(setUpFragment(getString(R.string.HistoryTab), publicKey), getString(R.string.HistoryTab))
+        viewPager.adapter = adapter
+    }
+
+    private fun setUpFragment(tabName: String, publicKey: String) : GameListFragment {
+        val args = Bundle()
+        args.putString("listFilter", tabName)
+        args.putString("publicKey", publicKey)
+        var frag = GameListFragment()
+        frag.arguments = args
+        return frag
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/SharedPreferences.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/SharedPreferences.kt
@@ -1,0 +1,46 @@
+package io.bitwise.sawtooth_xo
+
+import android.app.Activity
+import android.content.Context
+import sawtooth.sdk.signing.PrivateKey
+import sawtooth.sdk.signing.Secp256k1Context
+import sawtooth.sdk.signing.Secp256k1PrivateKey
+
+const val sharedPreferencePrivateKey = "private_key"
+const val sharedPreferencePublicKey = "public_key"
+
+fun getPrivateKey(activity: Activity) : Secp256k1PrivateKey {
+    var sharedPref = activity.getPreferences(Context.MODE_PRIVATE)
+    var privateKey = sharedPref.getString(sharedPreferencePrivateKey, "")
+    if(privateKey == "") {
+        privateKey = generatePrivateKey()
+        with (sharedPref.edit()) {
+            putString(sharedPreferencePrivateKey, privateKey)
+            apply()
+        }
+    }
+    return Secp256k1PrivateKey.fromHex(privateKey)
+}
+
+fun getPublicKey(activity: Activity, privateKey: PrivateKey) : String {
+    var sharedPref = activity.getPreferences(Context.MODE_PRIVATE)
+    var publicKey = sharedPref.getString(sharedPreferencePublicKey, "")
+    if(publicKey == "") {
+        publicKey = generatePublicKey(privateKey)
+        with (sharedPref.edit()) {
+            putString(sharedPreferencePublicKey, publicKey)
+            apply()
+        }
+    }
+    return publicKey
+}
+
+private fun generatePrivateKey() : String {
+    val context = Secp256k1Context()
+    return context.newRandomPrivateKey().hex()
+}
+
+private fun generatePublicKey(privateKey: PrivateKey) : String {
+    val context = Secp256k1Context()
+    return context.getPublicKey(privateKey).hex()
+}

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/adapters/PagerAdapter.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/adapters/PagerAdapter.kt
@@ -1,0 +1,29 @@
+package io.bitwise.sawtooth_xo.adapters
+
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
+import android.support.v4.app.FragmentPagerAdapter
+
+class PagerAdapter(fm: FragmentManager) : FragmentPagerAdapter(fm) {
+    private val mFragmentList = arrayListOf<Fragment>()
+    private val mFragmentTitleList = arrayListOf<String>()
+
+    override fun getItem(position: Int): Fragment {
+        return mFragmentList[position]
+    }
+
+    override fun getCount(): Int {
+        return mFragmentList.size
+    }
+
+    fun addFragment(fragment: Fragment, title: String) {
+        mFragmentList.add(fragment)
+        mFragmentTitleList.add(title)
+
+    }
+
+    override fun getPageTitle(position: Int): CharSequence? {
+        return mFragmentTitleList[position]
+    }
+
+}

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/models/Game.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/models/Game.kt
@@ -1,20 +1,11 @@
 package io.bitwise.sawtooth_xo.models
 
-class Game {
-    var name: String? = null
-    var board: String? = null
-    var gameState: String? = null
-    var playerKey1: String? = null
-    var playerKey2: String? = null
 
-    constructor(state: String) {
-        val split = state.split(',')
-        name = split[0]
-        board = split[1]
-        gameState = split[2]
-        playerKey1 = split[3]
-        playerKey2 = split[4]
-    }
+class Game( var name: String,
+            var board: String,
+            var gameState: String,
+            var playerKey1: String,
+            var playerKey2: String) {
 
     override fun toString(): String {
         return "Game(name=$name, board=$board, gameState=$gameState, playerKey1=$playerKey1, playerKey2=$playerKey2)"

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/Addressing.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/Addressing.kt
@@ -1,0 +1,21 @@
+package io.bitwise.sawtooth_xo.state
+
+import com.google.common.io.BaseEncoding
+import java.security.MessageDigest
+
+fun transactionFamilyPrefix() : String{
+    return hash("xo").substring(0,6)
+}
+
+fun hash(input: String) : String{
+    val digest = MessageDigest.getInstance("SHA-512")
+    digest.reset()
+    digest.update(input.toByteArray())
+    return BaseEncoding.base16().lowerCase().encode(digest.digest())
+}
+
+fun makeGameAddress(gameName: String) : String {
+    val xoPrefix = transactionFamilyPrefix()
+    val gameAddress = hash(gameName).substring(0, 64)
+    return xoPrefix + gameAddress
+}

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/XoStateRepository.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/state/XoStateRepository.kt
@@ -1,0 +1,59 @@
+package io.bitwise.sawtooth_xo.state
+
+import io.bitwise.sawtooth_xo.state.rest_api.SawtoothRestApi
+import retrofit2.Retrofit
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import android.util.Log
+import com.google.common.io.BaseEncoding
+import retrofit2.converter.gson.GsonConverterFactory
+import io.bitwise.sawtooth_xo.models.Game
+import io.bitwise.sawtooth_xo.state.rest_api.StateResponse
+import android.arch.lifecycle.MutableLiveData
+
+class XoStateRepository {
+    private var service: SawtoothRestApi? = null
+    var games : MutableLiveData<List<Game>> = MutableLiveData()
+
+    init {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("http://10.0.2.2:9708")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+        service = retrofit.create<SawtoothRestApi>(SawtoothRestApi::class.java)
+
+    }
+
+    fun  getState(update: Boolean)  {
+        val resp = arrayListOf<Game>()
+        if(update) {
+            service?.getState(transactionFamilyPrefix())?.enqueue(object : Callback<StateResponse> {
+                override fun onResponse(call: Call<StateResponse>, response: Response<StateResponse>) {
+                    if(response.body() != null) {
+                        response.body()?.data?.map{ entry ->
+
+                            resp.add(parseGame(entry.data))
+                        }
+                        games.value = resp.sortedBy { it.name.toLowerCase() }
+
+                        Log.d("XO.State", "Updated game list")
+                    } else {
+                        Log.d("XO.State", response.toString())
+                    }
+                }
+                override fun onFailure(call: Call<StateResponse>, t: Throwable) {
+                    Log.d("XO.State", t.toString())
+                    call.cancel()
+                }
+            })
+        }
+    }
+
+    private fun parseGame(data: String) : Game {
+        val decoded = String(BaseEncoding.base64().decode(data))
+        val split = decoded.split(',')
+        return Game(split[0], split[1], split[2], split[3], split[4])
+    }
+}

--- a/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/viewmodels/GameViewModel.kt
+++ b/examples/xo_android_client/app/src/main/java/io/bitwise/sawtooth_xo/viewmodels/GameViewModel.kt
@@ -5,22 +5,21 @@ import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
 import io.bitwise.sawtooth_xo.models.Game
-import io.bitwise.sawtooth_xo.state.XoState
+import io.bitwise.sawtooth_xo.state.XoStateRepository
 
 class GameViewModel : ViewModel(){
-    private val state: XoState = XoState()
-    var games: LiveData<List<Game>> = Transformations.switchMap(state.games) {input ->
+    private val stateRepository: XoStateRepository = XoStateRepository()
+    var games: LiveData<List<Game>> = Transformations.switchMap(stateRepository.games) { input ->
         var m = MutableLiveData<List<Game>>()
         m.value = input
         m
     }
 
     init {
-        state.getState(true)
+        stateRepository.getState(true)
     }
 
     fun loadGames(update: Boolean) {
-      state.getState(update)
+      stateRepository.getState(update)
     }
 }
-

--- a/examples/xo_android_client/app/src/main/res/layout/activity_main.xml
+++ b/examples/xo_android_client/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,11 @@
                 android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 
+        <android.support.design.widget.TabLayout
+                android:id="@+id/tabs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
     </android.support.design.widget.AppBarLayout>
 
     <android.support.design.widget.FloatingActionButton
@@ -35,14 +40,15 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:focusable="true"
             android:layout_marginBottom="16dp" android:layout_marginEnd="16dp" android:layout_marginRight="16dp"/>
-    <fragment
-            android:layout_width="0dp"
-            android:layout_height="0dp" android:name="io.bitwise.sawtooth_xo.GameListFragment"
-            android:id="@+id/fragment"
-            app:layout_constraintTop_toBottomOf="@+id/appbar" app:layout_constraintEnd_toEndOf="parent"
+
+    <android.support.v4.view.ViewPager
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/pager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp" app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintTop_toBottomOf="@+id/appbar" app:layout_constraintBottom_toBottomOf="parent"/>
+
 
 
 </android.support.constraint.ConstraintLayout>

--- a/examples/xo_android_client/app/src/main/res/values/strings.xml
+++ b/examples/xo_android_client/app/src/main/res/values/strings.xml
@@ -3,4 +3,7 @@
     <string name="enterGameName">Enter Game Name</string>
     <string name="sendBtn">Send</string>
     <string name="refreshBtn">Refresh</string>
+    <string name="PlayTab">Play</string>
+    <string name="WatchTab">Watch</string>
+    <string name="HistoryTab">History</string>
 </resources>


### PR DESCRIPTION
This PR includes some refactoring to allow for better management of the user's public and private keys. It also implements the three different tabs "PLAY", "SPECTATE" and "HISTORY" in the game list view. 

Play Tab
  <img src="https://user-images.githubusercontent.com/14094978/49243176-4d474c00-f3d2-11e8-8bc3-cd80993f0575.png" width="300">

Spectate tab
  <img src="https://user-images.githubusercontent.com/14094978/49243181-4e787900-f3d2-11e8-8ec2-6ab5aebeb518.png" width="300">
