### PR TITLE
Use user preference rest api url

### DIFF
--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/CreateGameActivity.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/CreateGameActivity.kt
@@ -42,14 +42,13 @@ class CreateGameActivity : AppCompatActivity() {
                     getRestApiUrl(this,
                         getString(R.string.rest_api_settings_key),
                         getString(R.string.default_rest_api_address))
-                ) {it ->
+                ) { it ->
                     if (it) {
                         Handler().postDelayed({
                             val intent = Intent(this, MainActivity::class.java)
                             startActivity(intent)
                         }, 1500)
                     }
-
                 }
             }
             true

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/GameBoardActivity.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/GameBoardActivity.kt
@@ -17,6 +17,7 @@ import bitwiseio.sawtooth.xo.models.Game
 import com.google.gson.Gson
 import bitwiseio.sawtooth.xo.state.api.XORequestHandler
 import bitwiseio.sawtooth.xo.viewmodels.GameBoardViewModel
+import bitwiseio.sawtooth.xo.viewmodels.ViewModelFactory
 import sawtooth.sdk.signing.Secp256k1PrivateKey
 
 class GameBoardActivity : AppCompatActivity(), View.OnClickListener {
@@ -44,12 +45,18 @@ class GameBoardActivity : AppCompatActivity(), View.OnClickListener {
 
         collectButtons()
 
-        model = ViewModelProviders.of(this).get(GameBoardViewModel::class.java)
+        model = ViewModelProviders.of(this, ViewModelFactory(getRestApiUrl(this,
+            getString(R.string.rest_api_settings_key),
+            getString(R.string.default_rest_api_address)))
+        ).get(GameBoardViewModel::class.java)
+
         model.game.observe(this, Observer<Game> { fetchedGame ->
             game = fetchedGame
             updateBoard()
         })
-        model.loadGame(game?.name!!)
+        model.loadGame(game?.name!!, getRestApiUrl(this,
+            getString(R.string.rest_api_settings_key),
+            getString(R.string.default_rest_api_address)))
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -59,7 +66,9 @@ class GameBoardActivity : AppCompatActivity(), View.OnClickListener {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
         R.id.refresh_board -> {
-            model.loadGame(game?.name!!)
+            model.loadGame(game?.name!!, getRestApiUrl(this,
+                getString(R.string.rest_api_settings_key),
+                getString(R.string.default_rest_api_address)))
             true
         }
         R.id.game_board_information -> {
@@ -146,7 +155,9 @@ class GameBoardActivity : AppCompatActivity(), View.OnClickListener {
                 getString(R.string.default_rest_api_address))
         ) { it ->
             if (it) {
-                model.loadGame(game?.name!!)
+                model.loadGame(game?.name!!, getRestApiUrl(this,
+                    getString(R.string.rest_api_settings_key),
+                    getString(R.string.default_rest_api_address)))
             }
         }
         v.setBackgroundColor(ContextCompat.getColor(this, R.color.selected_button))

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/GameListFragment.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/GameListFragment.kt
@@ -14,6 +14,7 @@ import android.view.ViewGroup
 import bitwiseio.sawtooth.xo.adapters.GameListRecyclerViewAdapter
 import bitwiseio.sawtooth.xo.models.Game
 import bitwiseio.sawtooth.xo.viewmodels.GameViewModel
+import bitwiseio.sawtooth.xo.viewmodels.ViewModelFactory
 
 /**
  * A fragment representing a list of Items.
@@ -29,7 +30,9 @@ class GameListFragment : Fragment() {
         super.onCreate(savedInstanceState)
 
         model = activity?.run {
-            ViewModelProviders.of(this).get(GameViewModel::class.java)
+            ViewModelProviders.of(this, ViewModelFactory(getRestApiUrl(activity!!,
+                getString(R.string.rest_api_settings_key),
+                getString(R.string.default_rest_api_address)))).get(GameViewModel::class.java)
         } ?: throw Exception("Invalid Activity")
     }
 

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/MainActivity.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/MainActivity.kt
@@ -15,6 +15,7 @@ import com.google.gson.Gson
 import bitwiseio.sawtooth.xo.adapters.PagerAdapter
 import bitwiseio.sawtooth.xo.models.Game
 import bitwiseio.sawtooth.xo.viewmodels.GameViewModel
+import bitwiseio.sawtooth.xo.viewmodels.ViewModelFactory
 
 class MainActivity : AppCompatActivity(), GameListFragment.OnListFragmentInteractionListener {
 
@@ -72,8 +73,12 @@ class MainActivity : AppCompatActivity(), GameListFragment.OnListFragmentInterac
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
         R.id.refresh_list -> {
-            val model = ViewModelProviders.of(this).get(GameViewModel::class.java)
-            model.loadGames(true)
+            val model = ViewModelProviders.of(this, ViewModelFactory(getRestApiUrl(this,
+                getString(R.string.rest_api_settings_key),
+                getString(R.string.default_rest_api_address)))).get(GameViewModel::class.java)
+            model.loadGames(true, getRestApiUrl(this,
+                getString(R.string.rest_api_settings_key),
+                getString(R.string.default_rest_api_address)))
             true
         }
         R.id.settings -> {

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/state/api/XORequestHandler.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/state/api/XORequestHandler.kt
@@ -38,7 +38,7 @@ class XORequestHandler(private var restApiURL: String, privateKey: PrivateKey) {
         checkURLChanged(restApiURL)
         val createGameTransaction = makeTransaction(gameName, "create", null)
         val batch = makeBatch(arrayOf(createGameTransaction))
-        sendRequest(batch, view, callback={ it->
+        sendRequest(batch, view, callback = { it ->
             callback(it)
         })
     }
@@ -47,7 +47,7 @@ class XORequestHandler(private var restApiURL: String, privateKey: PrivateKey) {
         checkURLChanged(restApiURL)
         val takeSpaceTransaction = makeTransaction(gameName, "take", space)
         val batch = makeBatch(arrayOf(takeSpaceTransaction))
-        sendRequest(batch, view, callback={ it->
+        sendRequest(batch, view, callback = { it ->
             callback(it)
         })
     }
@@ -121,7 +121,7 @@ class XORequestHandler(private var restApiURL: String, privateKey: PrivateKey) {
             override fun onResponse(call: Call<BatchListResponse>, response: Response<BatchListResponse>) {
                 if (response.body() != null) {
                     Log.d("XO.State", response.body().toString())
-                    waitForBatch(response.body()?.link, 5, view, callback={ it ->
+                    waitForBatch(response.body()?.link, 5, view, callback = { it ->
                         callback(it)
                     })
                 } else {
@@ -162,10 +162,10 @@ class XORequestHandler(private var restApiURL: String, privateKey: PrivateKey) {
     }
 
     private fun handleBatchStatus(batchResponse: BatchStatusResponse): String {
-        val status = batchResponse.data?.get(0)?.status
+        val status = batchResponse.data[0].status
         when (status) {
             "INVALID" -> {
-                val invalidTransaction = batchResponse.data?.get(0)?.invalidTransactions[0]
+                val invalidTransaction = batchResponse.data[0].invalidTransactions[0]
                 Log.d("XO.State", invalidTransaction.id)
                 Log.d("XO.State", invalidTransaction.message)
                 return invalidTransaction.message.toString()

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/viewmodels/GameBoardViewModel.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/viewmodels/GameBoardViewModel.kt
@@ -7,8 +7,8 @@ import android.arch.lifecycle.ViewModel
 import bitwiseio.sawtooth.xo.models.Game
 import bitwiseio.sawtooth.xo.state.XoStateRepository
 
-class GameBoardViewModel : ViewModel() {
-    private val stateRepository: XoStateRepository = XoStateRepository()
+class GameBoardViewModel(url: String) : ViewModel() {
+    private var stateRepository: XoStateRepository = XoStateRepository(url)
     var game: LiveData<Game> = Transformations.switchMap(stateRepository.gameFocus) { input ->
         var m = MutableLiveData<Game>()
         m.value = input
@@ -17,8 +17,8 @@ class GameBoardViewModel : ViewModel() {
 
     init { }
 
-    fun loadGame(name: String) {
-        stateRepository.getGameState(name)
+    fun loadGame(name: String, url: String) {
+        stateRepository.getGameState(name, url)
         game = stateRepository.gameFocus
     }
 }

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/viewmodels/GameViewModel.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/viewmodels/GameViewModel.kt
@@ -7,8 +7,8 @@ import android.arch.lifecycle.ViewModel
 import bitwiseio.sawtooth.xo.models.Game
 import bitwiseio.sawtooth.xo.state.XoStateRepository
 
-class GameViewModel : ViewModel() {
-    private val stateRepository: XoStateRepository = XoStateRepository()
+class GameViewModel(initUrl: String) : ViewModel() {
+    private var stateRepository: XoStateRepository = XoStateRepository(initUrl)
     var games: LiveData<List<Game>> = Transformations.switchMap(stateRepository.games) { input ->
         var m = MutableLiveData<List<Game>>()
         m.value = input
@@ -16,10 +16,10 @@ class GameViewModel : ViewModel() {
     }
 
     init {
-        stateRepository.getState(true)
+        stateRepository.getState(true, initUrl)
     }
 
-    fun loadGames(update: Boolean) {
-        stateRepository.getState(update)
+    fun loadGames(update: Boolean, url: String) {
+        stateRepository.getState(update, url)
     }
 }

--- a/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/viewmodels/ViewModelFactory.kt
+++ b/examples/xo_android_client/app/src/main/java/bitwiseio/sawtooth/xo/viewmodels/ViewModelFactory.kt
@@ -1,0 +1,16 @@
+package bitwiseio.sawtooth.xo.viewmodels
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+
+class ViewModelFactory(private val restApiUrl: String) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        return when (modelClass) {
+            GameViewModel::class.java -> GameViewModel(restApiUrl) as T
+            GameBoardViewModel::class.java -> GameBoardViewModel(restApiUrl) as T
+            else -> null as T
+        }
+    }
+}


### PR DESCRIPTION
Alters the XoStateRepository, which handles the data for the game list and game board view to use the rest api url from the user's preferences rather than hardcoded. This includes using a ViewModelFactory in order to pass this url string to the XoStateRepository instance which is created within the ViewModels, outside of the activities. 