### PR TITLE
Add scroll view to game board

### DIFF
--- a/examples/xo_android_client/app/src/main/res/layout/activity_game_board.xml
+++ b/examples/xo_android_client/app/src/main/res/layout/activity_game_board.xml
@@ -37,120 +37,130 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintHorizontal_bias="0.0" app:layout_constraintTop_toBottomOf="@+id/game_board_name"
             android:layout_marginTop="8dp" android:layout_marginLeft="16dp" android:layout_marginStart="16dp"/>
-    <TableLayout
-            android:layout_width="368dp"
-            android:layout_height="427dp"
-            app:layout_constraintStart_toStartOf="parent" android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp" android:layout_marginEnd="8dp" android:layout_marginRight="8dp"
-            app:layout_constraintEnd_toEndOf="parent" android:layout_marginTop="8dp"
-            app:layout_constraintTop_toBottomOf="@+id/game_board_state" android:layout_marginBottom="8dp"
-            app:layout_constraintBottom_toBottomOf="parent" android:gravity="center" android:id="@+id/game_table">
+    <ScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            app:layout_constraintEnd_toEndOf="parent" app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:scrollbarStyle="insideOverlay"
+            android:clipToPadding="true" android:fillViewport="true"
+            android:layout_marginBottom="4dp" android:layout_marginTop="4dp"
+            app:layout_constraintTop_toBottomOf="@+id/game_board_name">
+        <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent" android:layout_marginLeft="8dp"
+                android:layout_marginStart="8dp" android:layout_marginEnd="8dp" android:layout_marginRight="8dp"
+                app:layout_constraintEnd_toEndOf="parent" android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@+id/game_board_state" android:layout_marginBottom="8dp"
+                app:layout_constraintBottom_toBottomOf="parent" android:gravity="center" android:id="@+id/game_table">
 
-        <TableRow android:layout_width="wrap_content"
-                  android:layout_height="wrap_content" android:id="@+id/board_row_1">
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp"
-                    android:textColor="@color/text"
-                    android:id="@+id/button1" android:background=
-                            "@color/design_default_color_primary" android:textSize="30sp"/>
-            <Space
-                    android:layout_width="5dp"
-                    android:layout_height="match_parent"/>
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button2"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-            <Space
-                    android:layout_width="5dp"
-                    android:layout_height="match_parent"/>
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button3"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-        </TableRow>
-        <TableRow
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" android:id="@+id/space_row_1">
-            <Space
+            <TableRow android:layout_width="wrap_content"
+                      android:layout_height="wrap_content" android:id="@+id/board_row_1">
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp"
+                        android:textColor="@color/text"
+                        android:id="@+id/button1" android:background=
+                                "@color/design_default_color_primary" android:textSize="30sp"/>
+                <Space
+                        android:layout_width="5dp"
+                        android:layout_height="match_parent"/>
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button2"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+                <Space
+                        android:layout_width="5dp"
+                        android:layout_height="match_parent"/>
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button3"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+            </TableRow>
+            <TableRow
                     android:layout_width="match_parent"
-                    android:layout_height="5dp"/>
-        </TableRow>
-        <TableRow android:layout_width="wrap_content" android:layout_height="wrap_content"
-                  android:id="@+id/board_row_2">
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button4"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-            <Space
-                    android:layout_width="5dp"
-                    android:layout_height="match_parent"/>
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button5"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-            <Space
-                    android:layout_width="5dp"
-                    android:layout_height="match_parent"/>
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button6"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-        </TableRow>
-        <TableRow
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" android:id="@+id/space_row_2">
-            <Space
+                    android:layout_height="match_parent" android:id="@+id/space_row_1">
+                <Space
+                        android:layout_width="match_parent"
+                        android:layout_height="5dp"/>
+            </TableRow>
+            <TableRow android:layout_width="wrap_content" android:layout_height="wrap_content"
+                      android:id="@+id/board_row_2">
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button4"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+                <Space
+                        android:layout_width="5dp"
+                        android:layout_height="match_parent"/>
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button5"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+                <Space
+                        android:layout_width="5dp"
+                        android:layout_height="match_parent"/>
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button6"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+            </TableRow>
+            <TableRow
                     android:layout_width="match_parent"
-                    android:layout_height="5dp"/>
-        </TableRow>
-        <TableRow android:layout_width="wrap_content" android:layout_height="wrap_content"
-                  android:id="@+id/board_row_3">
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button7"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-            <Space
-                    android:layout_width="5dp"
-                    android:layout_height="match_parent"/>
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button8"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-            <Space
-                    android:layout_width="5dp"
-                    android:layout_height="match_parent"/>
-            <Button
-                    android:text="@string/game_button"
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:layout_width="122dp"
-                    android:layout_height="122dp" android:id="@+id/button9"
-                    android:textColor="@color/text"
-                    android:background="@color/design_default_color_primary" android:textSize="30sp"/>
-        </TableRow>
-    </TableLayout>
+                    android:layout_height="match_parent" android:id="@+id/space_row_2">
+                <Space
+                        android:layout_width="match_parent"
+                        android:layout_height="5dp"/>
+            </TableRow>
+            <TableRow android:layout_width="wrap_content" android:layout_height="wrap_content"
+                      android:id="@+id/board_row_3">
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button7"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+                <Space
+                        android:layout_width="5dp"
+                        android:layout_height="match_parent"/>
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button8"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+                <Space
+                        android:layout_width="5dp"
+                        android:layout_height="match_parent"/>
+                <Button
+                        android:text="@string/game_button"
+                        style="?android:attr/buttonBarButtonStyle"
+                        android:layout_width="122dp"
+                        android:layout_height="122dp" android:id="@+id/button9"
+                        android:textColor="@color/text"
+                        android:background="@color/design_default_color_primary" android:textSize="30sp"/>
+            </TableRow>
+        </TableLayout>
+    </ScrollView>
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Adds a scroll view to the GameBoard view layout to allow for scrolling when the game board is cut off, particularly when the orientation changes.

Signed-off-by: Shannyn Telander <telander@bitwise.io>