### PR TITLE
Change dependencies to use published Sawtooth SDK

### DIFF
--- a/examples/xo_android_client/app/build.gradle
+++ b/examples/xo_android_client/app/build.gradle
@@ -33,8 +33,8 @@ android {
 }
 
 dependencies {
-    implementation files('libs/sawtooth-sdk-signing-v0.1.2-SNAPSHOT.jar')
-    implementation files('libs/sawtooth-sdk-protos-v0.1.2-SNAPSHOT.jar')
+    implementation 'org.hyperledger.sawtooth:sawtooth-sdk-signing:v0.1.2'
+    implementation 'org.hyperledger.sawtooth:sawtooth-sdk-protos:v0.1.2'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
     implementation 'com.google.protobuf:protobuf-java:3.6.1'

--- a/examples/xo_android_client/build.gradle
+++ b/examples/xo_android_client/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
@@ -19,6 +20,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This updates the dependencies to used the
published Sawtooth Java SDK rather than
a local version.

Signed-off-by: Eloá França Verona <eloafran@bitwise.io>